### PR TITLE
fix build on gcc 13.2.1 from fedora 38 & 39

### DIFF
--- a/quic/server/test/QuicServerTest.cpp
+++ b/quic/server/test/QuicServerTest.cpp
@@ -1719,9 +1719,7 @@ TEST_F(QuicServerWorkerTakeoverTest, QuicServerTakeoverReInitHandler) {
 
   EXPECT_CALL(*takeoverSock, bind(_, _));
   EXPECT_CALL(*takeoverSock, resumeRead(_));
-  EXPECT_CALL(*takeoverSock, address()).WillOnce(Invoke([&]() {
-    return takeoverAddr;
-  }));
+  EXPECT_CALL(*takeoverSock, address()).WillOnce(ReturnRef(takeoverAddr));
   takeoverWorker_->overrideTakeoverHandlerAddress(
       std::move(takeoverSock), takeoverAddr);
   takeoverSocket_ = takeoverSock.get();


### PR DESCRIPTION
fix build on gcc 13.2.1 from fedora 38 & 39

mvfst build breaks on recent GCC, fix it

Test plan:

Build locally with:  ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mvfst

Before, breaks with
```
FAILED: quic/server/test/CMakeFiles/QuicServerTest.dir/QuicServerTest.cpp.o
/usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DGFLAGS_IS_A_DLL=0 -DQuicServerTest_EXPORTS -I/home/alex/local/mvfst/quic/server/test -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/googletest-0ze4i4cx2kwdhVWbocTwVSZkTpJB4Lx7fEhes9x5am0/include -I/home/alex/local/mvfst -I/home/alex/local/mvfst/quic/common/test -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/folly/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/fmt-xbSqy3wXaPfgRPtU_3Lam9o7QTL1QbjTmhOeSpp5C00/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/fizz/include -O2 -g -DNDEBUG -std=c++17 -Wall -Wextra -Wno-sign-compare -MD -MT quic/server/test/CMakeFiles/QuicServerTest.dir/QuicServerTest.cpp.o -MF quic/server/test/CMakeFiles/QuicServerTest.dir/QuicServerTest.cpp.o.d -o quic/server/test/CMakeFiles/QuicServerTest.dir/QuicServerTest.cpp.o -c /home/alex/local/mvfst/quic/server/test/QuicServerTest.cpp
In file included from /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/googletest-0ze4i4cx2kwdhVWbocTwVSZkTpJB4Lx7fEhes9x5am0/include/gmock/gmock.h:56,
                 from /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/folly/include/folly/portability/GMock.h:32,
                 from /home/alex/local/mvfst/quic/server/test/QuicServerTest.cpp:12:
/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/googletest-0ze4i4cx2kwdhVWbocTwVSZkTpJB4Lx7fEhes9x5am0/include/gmock/gmock-actions.h: In instantiation of ‘testing::OnceAction<Result(Args ...)>::OnceAction(Callable&&) [with Callable = quic::test::QuicServerWorkerTakeoverTest_QuicServerTakeoverReInitHandler_Test::TestBody()::<lambda()>; typename std::enable_if<testing::internal::conjunction<testing::internal::negation<std::is_same<testing::OnceAction<Result(Args ...)>, typename std::decay<_Func>::type> >, IsDirectlyCompatible<Callable> >::value, int>::type <anonymous> = 0; Result = const folly::SocketAddress&; Args = {}]’:
/home/alex/local/mvfst/quic/server/test/QuicServerTest.cpp:1732:49:   required from here
/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/googletest-0ze4i4cx2kwdhVWbocTwVSZkTpJB4Lx7fEhes9x5am0/include/gmock/gmock-actions.h:459:9: error: no matching function for call to ‘std::function<const folly::SocketAddress&()>::function(testing::OnceAction<const folly::SocketAddress&()>::StdFunctionAdaptor<quic::test::QuicServerWorkerTakeoverTest_QuicServerTakeoverReInitHandler_Test::TestBody()::<lambda()> >)’
  459 |       : function_(StdFunctionAdaptor<typename std::decay<Callable>::type>(
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  460 |             {}, std::forward<Callable>(callable))) {}
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/13/functional:59,
                 from /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/folly/include/folly/ScopeGuard.h:75,
                 from /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZmvfstZbuildZfbcode_builder/installed/folly/include/folly/ThreadLocal.h:50,
                 from /home/alex/local/mvfst/quic/server/QuicServer.h:14,
                 from /home/alex/local/mvfst/quic/server/test/QuicServerTest.cpp:8:
/usr/include/c++/13/bits/std_function.h:435:9: note: candidate: ‘template<class _Functor, class _Constraints> std::function<_Res(_ArgTypes ...)>::function(_Functor&&) [with _Constraints = _Functor; _Res = const folly::SocketAddress&; _ArgTypes = {}]’
  435 |         function(_Functor&& __f)
      |         ^~~~~~~~
/usr/include/c++/13/bits/std_function.h:435:9: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/13/ratio:39,
                 from /usr/include/c++/13/bits/chrono.h:37,
                 from /usr/include/c++/13/condition_variable:40,
                 from /home/alex/local/mvfst/quic/server/QuicServer.h:10:
```

After, build works, and tests pass locally with: ./build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mvfst

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/mvfst/pull/315).
* #330
* __->__ #315