### PR TITLE
fix build with Ubuntu 20.04's cmake

### DIFF
--- a/quic/dsr/CMakeLists.txt
+++ b/quic/dsr/CMakeLists.txt
@@ -7,8 +7,6 @@ add_library(
   mvfst_dsr_sender INTERFACE
 )
 
-set_property(TARGET mvfst_dsr_sender PROPERTY VERSION ${PACKAGE_VERSION})
-
 target_include_directories(
   mvfst_dsr_sender INTERFACE
   $<BUILD_INTERFACE:${QUIC_FBCODE_ROOT}>


### PR DESCRIPTION
Summary:
Setting the `VERSION` property on an `INTERFACE` target is invalid at least on
Ubuntu 20.04's cmake 3.16.3. This breaks mcrouter's build using the scripts in
`mcrouter/scripts`

Differential Revision: D50094004


