### PR TITLE
echo client: use QUIC v1 (RFC 9000)

### DIFF
--- a/quic/samples/echo/EchoClient.h
+++ b/quic/samples/echo/EchoClient.h
@@ -208,6 +208,7 @@ class EchoClient : public quic::QuicSocket::ConnectionSetupCallback,
           qEvb, std::move(sock), std::move(fizzClientContext));
       quicClient_->setHostname("echo.com");
       quicClient_->addNewPeerAddress(addr);
+      quicClient_->setSupportedVersions({QuicVersion::QUIC_V1});
       if (!token.empty()) {
         quicClient_->setNewToken(token);
       }


### PR DESCRIPTION
... and not an internal Facebook QUIC version. Makes testing against other QUIC stacks either.
I haven't figured out how to set the ALPN though.