### PR TITLE
use system deps in github CI for mac and linux

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -10,98 +10,107 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Update system package info
+      run: sudo apt-get update
+    - name: Install system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mvfst
+    - name: Install packaging system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch zlib
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build zlib
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build lz4
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build autoconf
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Build libtool
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build mvfst
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. mvfst _artifacts/linux  --project-install-prefix mvfst:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. mvfst _artifacts/linux  --project-install-prefix mvfst:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v2
       with:
         name: mvfst
         path: _artifacts
     - name: Test mvfst
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -10,102 +10,107 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Install system deps
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mvfst
     - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch zlib
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch lz4
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch openssl
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build zlib
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build lz4
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
     - name: Build openssl
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build autoconf
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Build libtool
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build mvfst
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. mvfst _artifacts/mac  --project-install-prefix mvfst:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. mvfst _artifacts/mac  --project-install-prefix mvfst:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v2
       with:
         name: mvfst
         path: _artifacts
     - name: Test mvfst
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mvfst  --project-install-prefix mvfst:/usr/local

--- a/quic/server/test/QuicServerTest.cpp
+++ b/quic/server/test/QuicServerTest.cpp
@@ -1719,9 +1719,7 @@ TEST_F(QuicServerWorkerTakeoverTest, QuicServerTakeoverReInitHandler) {
 
   EXPECT_CALL(*takeoverSock, bind(_, _));
   EXPECT_CALL(*takeoverSock, resumeRead(_));
-  EXPECT_CALL(*takeoverSock, address()).WillOnce(Invoke([&]() {
-    return takeoverAddr;
-  }));
+  EXPECT_CALL(*takeoverSock, address()).WillOnce(ReturnRef(takeoverAddr));
   takeoverWorker_->overrideTakeoverHandlerAddress(
       std::move(takeoverSock), takeoverAddr);
   takeoverSocket_ = takeoverSock.get();


### PR DESCRIPTION
use system deps in github CI for mac and linux

speed up the github CI by not rebuilding boost every time

Regenerated tha actions with
```
./build/fbcode_builder/getdeps.py generate-github-actions --allow-system-packages --src-dir=. --os-type=darwin --output-dir=.github/workflows mvfst
./build/fbcode_builder/getdeps.py generate-github-actions --allow-system-packages --src-dir=. --os-type=linux --output-dir=.github/workflows mvfst
```

Test Plan:

CI
