### PR TITLE
Fix CMake build

### DIFF
--- a/quic/api/CMakeLists.txt
+++ b/quic/api/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   QuicPacketScheduler.cpp
   QuicStreamAsyncTransport.cpp
   QuicTransportBase.cpp
+  QuicTransportBaseLite.cpp
   QuicTransportFunctions.cpp
 )
 

--- a/quic/state/CMakeLists.txt
+++ b/quic/state/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   mvfst_state_ack_handler
   AckEvent.cpp
   AckHandlers.cpp
+  AckedPacketIterator.cpp
 )
 
 set_property(TARGET mvfst_state_ack_handler PROPERTY VERSION ${PACKAGE_VERSION})


### PR DESCRIPTION
We need some source files declared in the relevant `CMakeLists.txt`s to mirror the analogous `BUCK` files.