### PR TITLE
Convert directory fbcode/opensource to use the Ruff Formatter

### DIFF
--- a/build/fbcode_builder/CMake/fb_py_test_main.py
+++ b/build/fbcode_builder/CMake/fb_py_test_main.py
@@ -6,7 +6,6 @@
 This file contains the main module code for Python test programs.
 """
 
-
 import contextlib
 import ctypes
 import fnmatch
@@ -50,7 +49,6 @@ EXIT_CODE_TEST_FAILURE = 70
 
 
 class TestStatus(object):
-
     ABORTED = "FAILURE"
     PASSED = "SUCCESS"
     FAILED = "FAILURE"
@@ -230,7 +228,6 @@ class BuckTestResult(unittest.TextTestResult):
         """
 
         for test in suite:
-
             # We identify test suites by test that are iterable (as is done in
             # the builtin python test harness).  If we see one, recurse on it.
             if hasattr(test, "__iter__"):
@@ -429,7 +426,6 @@ class RegexTestLoader(unittest.TestLoader):
 
 
 class Loader(object):
-
     suiteClass = unittest.TestSuite
 
     def __init__(self, modules, regex=None):

--- a/build/fbcode_builder/CMake/make_fbpy_archive.py
+++ b/build/fbcode_builder/CMake/make_fbpy_archive.py
@@ -156,9 +156,7 @@ def create_main_module(args, inst_dir, path_map):
 if __name__ == "__main__":
     import {main_module}
     {main_module}.{main_fn}()
-""".format(
-        python=args.python, main_module=main_module, main_fn=main_fn
-    )
+""".format(python=args.python, main_module=main_module, main_fn=main_fn)
     with open(dest_path, "w") as f:
         f.write(main_contents)
     os.chmod(dest_path, 0o755)

--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -286,7 +286,6 @@ class MakeBuilder(BuilderBase):
         return ["PREFIX=" + self.inst_dir, "prefix=" + self.inst_dir]
 
     def _build(self, reconfigure) -> None:
-
         env = self._compute_env()
 
         # Need to ensure that PREFIX is set prior to install because

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -128,7 +128,6 @@ class BuildOptions(object):
         self.lib_path = lib_path
 
         if vcvars_path is None and is_windows():
-
             try:
                 # Allow a site-specific vcvarsall path.
                 from .facebook.vcvarsall import build_default_vcvarsall

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -112,9 +112,7 @@ target-dir = '''{}'''
 [profile.dev]
 debug = false
 incremental = false
-""".format(
-                self.build_dir.replace("\\", "\\\\")
-            )
+""".format(self.build_dir.replace("\\", "\\\\"))
 
         # Point to vendored sources from getdeps manifests
         for _dep, git_conf in dep_to_git.items():

--- a/build/fbcode_builder/getdeps/dyndeps.py
+++ b/build/fbcode_builder/getdeps/dyndeps.py
@@ -328,9 +328,7 @@ try {{
 }} finally {{
     $env:PATH = $orig_env
 }}
-""".format(
-            path_str=path_str
-        )
+""".format(path_str=path_str)
 
 
 class ElfDeps(DepBase):


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9522

X-link: https://github.com/facebook/folly/pull/2318

X-link: https://github.com/facebook/fboss/pull/277

X-link: https://github.com/facebook/fb303/pull/59

Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files

Reviewed By: amyreese

Differential Revision: D64265365


