### PR TITLE
Fix compilation error in optional.h when trying to compile watchman.

### DIFF
--- a/quic/common/third-party/optional.h
+++ b/quic/common/third-party/optional.h
@@ -33,6 +33,7 @@ Original repository: https://github.com/Sedeniono/tiny-optional
 #include <cassert>
 #include <climits>
 #include <cstdint> // Required for std::uint64_t etc.
+#include <cstdlib> // Required for std::abort.
 #include <cstring> // Required for memcpy
 #include <functional> // Required for std::hash and std::invoke
 #include <limits> // Required for std::numeric_limits


### PR DESCRIPTION
```
FAILED: quic/dsr/CMakeFiles/mvfst_dsr_frontend.dir/frontend/Scheduler.cpp.o 
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DGFLAGS_IS_A_DLL=0 -I/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git -isystem /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/installed/boost-WWAdUuDHG4SZiSWNWLTtXVV60aeQCkRT_TY1CGrKCz0/include -isystem /usr/include/libdwarf -isystem /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/installed/folly/include -isystem /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/installed/fmt-sUAsk0jwHE0LTHTgdPkn_3B2kUYhIToULRKySRDSjoI/include -isystem /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/installed/fizz/include -O2 -g -DNDEBUG -std=c++17 -Wall -Wextra -Woverloaded-virtual -Wnon-virtual-dtor -Wtype-limits -Wunused-value -MD -MT quic/dsr/CMakeFiles/mvfst_dsr_frontend.dir/frontend/Scheduler.cpp.o -MF quic/dsr/CMakeFiles/mvfst_dsr_frontend.dir/frontend/Scheduler.cpp.o.d -o quic/dsr/CMakeFiles/mvfst_dsr_frontend.dir/frontend/Scheduler.cpp.o -c /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/dsr/frontend/Scheduler.cpp
In file included from /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/Optional.h:12,
                 from /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/codec/QuicConnectionId.h:10,
                 from /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/dsr/frontend/PacketBuilder.h:11,
                 from /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/dsr/frontend/Scheduler.h:10,
                 from /tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/dsr/frontend/Scheduler.cpp:8:
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h: In member function ‘quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::PayloadType& quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::value() &’:
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h:1591:14: error: ‘abort’ is not a member of ‘std’
 1591 |         std::abort();
      |              ^~~~~
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h: In member function ‘const quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::PayloadType& quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::value() const &’:
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h:1600:14: error: ‘abort’ is not a member of ‘std’
 1600 |         std::abort();
      |              ^~~~~
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h: In member function ‘quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::PayloadType&& quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::value() &&’:
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h:1609:14: error: ‘abort’ is not a member of ‘std’
 1609 |         std::abort();
      |              ^~~~~
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h: In member function ‘const quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::PayloadType&& quic::detail::tiny::quic_tiny_opt_100300_noBit_noMem::impl::TinyOptionalImpl<StoredTypeDecomposition, FlagManipulator>::value() const &&’:
/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/repos/github.com-facebook-mvfst.git/quic/common/third-party/optional.h:1618:14: error: ‘abort’ is not a member of ‘std’
 1618 |         std::abort();
      |              ^~~~~
ninja: build stopped: subcommand failed.
Command '['/usr/bin/cmake', '--build', '/tmp/fbcode_builder_getdeps-ZusrZlocalZgoogleZhomeZmstaZwatchmanZbuildZfbcode_builder/build/mvfst', '--target', 'install', '--config', 'RelWithDebInfo', '-j', '111']' returned non-zero exit status 1.
!! Failed
```