### PR TITLE
Remove DSR libraries from CMake config

### DIFF
--- a/cmake/mvfst-config.cmake.in
+++ b/cmake/mvfst-config.cmake.in
@@ -46,8 +46,6 @@ set(mvfst_LIBRARIES
   mvfst::mvfst_bufutil
   mvfst::mvfst_transport_knobs
   mvfst::mvfst_cc_algo
-  mvfst::mvfst_dsr_types
-  mvfst::mvfst_dsr_frontend
   mvfst::mvfst_fizz_client
   mvfst::mvfst_fizz_handshake
   mvfst::mvfst_flowcontrol


### PR DESCRIPTION
These libraries were removed in fc66b078593e8f87af6a85bd32e3dd2ee9646347.

The corresponding targets should be removed from the CMake config or
else doing `find_package(mvfst)` in CMake will fail due to the missing
libraries.
