### PR TITLE
cmake: do not install tperf binary

### DIFF
--- a/quic/tools/tperf/CMakeLists.txt
+++ b/quic/tools/tperf/CMakeLists.txt
@@ -33,10 +33,3 @@ target_link_libraries(
   ${GFLAGS_LIBRARIES}
   ${LIBGMOCK_LIBRARIES}
 )
-
-install(
-  TARGETS tperf
-  EXPORT mvfst-exports
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_DIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_DIR}
-)


### PR DESCRIPTION
## Summary
- `tperf` is installed via CMake but depends on `mvfst_test_utils` and transitively on `mvfst_dsr_backend`, which are not installed
- This causes unresolved soname dependency errors at runtime:
  ```
  /usr/bin/tperf: libmvfst_dsr_backend.so.0 libmvfst_test_utils.so.0
  ```
- Removed the `install()` directive since `tperf` is a test/benchmarking tool (guarded by `BUILD_TESTS`, links gmock/gtest) and should not be installed as a production binary
- The binary remains available in the build directory for local benchmarking

## Test plan
- Verified `tperf` is only built when `BUILD_TESTS` is enabled (line 6-8: `if(NOT BUILD_TESTS) return()`)
- Verified `tperf` links test-only libraries: `mvfst_test_utils`, `${LIBGMOCK_LIBRARIES}`
- Confirmed no other CMake targets depend on an installed `tperf`
- Grepped the codebase: no references to tperf in export/install outside this file

Closes #381