### PR TITLE
Snappy manifest patched to build with RTTI enabled. Pex installed with pipx for Debian based linux environments.

### DIFF
--- a/build/fbcode_builder/getdeps/cli.py
+++ b/build/fbcode_builder/getdeps/cli.py
@@ -291,7 +291,8 @@ class InstallSysDepsCmd(ProjectCmdBase):
                     ]
                     + packages
                 )
-                cmd_argss.append(["pip", "install", "pex"])
+                cmd_argss.append(["pipx", "ensurepath"])
+                cmd_argss.append(["pipx", "install", "pex"])
         elif manager == "homebrew":
             packages = sorted(set(all_packages["homebrew"]))
             if packages:

--- a/build/fbcode_builder/manifests/mvfst
+++ b/build/fbcode_builder/manifests/mvfst
@@ -27,6 +27,9 @@ fizz
 [dependencies.all(test=on, not(os=windows))]
 googletest
 
+[debs]
+pipx
+
 [shipit.pathmap]
 fbcode/quic/public_root = .
 fbcode/quic = quic

--- a/build/fbcode_builder/manifests/snappy
+++ b/build/fbcode_builder/manifests/snappy
@@ -20,6 +20,7 @@ sha256 = d0ce758440920c0e636579da02092296a64aed5a8296e1175fdf1783a8440082
 [build]
 builder = cmake
 subdir = snappy-27ab5f7f518430a021239bc26a5b2fd64affbc7b
+patchfile = snappy_keep_rtti.patch
 
 [cmake.defines]
 SNAPPY_BUILD_TESTS = OFF

--- a/build/fbcode_builder/patches/snappy_keep_rtti.patch
+++ b/build/fbcode_builder/patches/snappy_keep_rtti.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ac43da3..b158074 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,9 +52,6 @@ if(MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+ 
+-  # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(MSVC)
+    # Use -Wall for clang and gcc.
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -82,9 +79,6 @@ else(MSVC)
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+ 
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make


### PR DESCRIPTION
**Description**

1. For deb linux we use pipx to install pex
2. For building we patch Snappy to enable RTTI which is needed by Folly compression package. 

Fixes #457

**Environment**

**OS**: Ubuntu 24.04 Linux  6.17.0-23-generic 23~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC x86_64 x86_64 x86_64 GNU/Linux
**Python**: Python 3.12.3

**Evidence**

<details>
<summary>Fixed getdeps.py script for Ubuntu 24.04 and python3.12</summary>

```
mvfst git:(bugfix/issue-457-build) sudo ./build/fbcode_builder/getdeps.py install-system-deps --recursive --install-prefix=$(pwd)/_build mvfst
---
+ sudo \
+      --preserve-env=http_proxy \
+      apt-get \
+      install \
+      -y \
+      autoconf \
+      automake \
+      binutils-x86-64-linux-gnu \
+      cmake \
+      libaio-dev \
+      libclang-dev \
+      libdouble-conversion-dev \
+      libdwarf-dev \
+      libevent-dev \
+      libgflags-dev \
+      libgmock-dev \
+      libgtest-dev \
+      liblz4-dev \
+      libsnappy-dev \
+      libsodium-dev \
+      libssl-dev \
+      libtool \
+      libzstd-dev \
+      ninja-build \
+      pipx \
+      zlib1g-dev \
+      zstd
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
autoconf is already the newest version (2.71-3).
automake is already the newest version (1:1.16.5-1.3ubuntu1).
binutils-x86-64-linux-gnu is already the newest version (2.42-4ubuntu2.10).
cmake is already the newest version (3.28.3-1build7).
libaio-dev is already the newest version (0.3.113-6build1.1).
libclang-dev is already the newest version (1:18.0-59~exp2).
libdouble-conversion-dev is already the newest version (3.3.0-1build1).
libdwarf-dev is already the newest version (20210528-1build2).
libevent-dev is already the newest version (2.1.12-stable-9ubuntu2).
libgflags-dev is already the newest version (2.2.2-2build1).
libgmock-dev is already the newest version (1.14.0-1).
libgtest-dev is already the newest version (1.14.0-1).
liblz4-dev is already the newest version (1.9.4-1build1.1).
libsnappy-dev is already the newest version (1.1.10-1build1).
libsodium-dev is already the newest version (1.0.18-1ubuntu0.24.04.1).
libssl-dev is already the newest version (3.0.13-0ubuntu3.9).
libtool is already the newest version (2.4.7-7build1).
libzstd-dev is already the newest version (1.5.5+dfsg2-2build1.1).
ninja-build is already the newest version (1.11.1-2).
pipx is already the newest version (1.4.3-1).
zlib1g-dev is already the newest version (1:1.3.dfsg-3.1ubuntu2.1).
zstd is already the newest version (1.5.5+dfsg2-2build1.1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
---
+ pipx \
+      ensurepath
/root/.local/bin has been been added to PATH, but you need to open a new terminal or re-login for this PATH change to take effect.

You will need to open a new terminal or re-login for the PATH changes to take effect.

Otherwise pipx is ready to go! ✨ 🌟 ✨
---
+ pipx \
+      install \
+      pex
'pex' already seems to be installed. Not modifying existing installation in '/root/.local/share/pipx/venvs/pex'. Pass '--force' to force installation.
no packages to install
```
</details>

<details>
<summary>Building with ./getdeps.sh</summary>

```
mvfst git:(bugfix/issue-457-build) ./getdeps.sh                                                                                               
+ TOOLCHAIN_DIR=/opt/rh/devtoolset-8/root/usr/bin
+ [[ -d /opt/rh/devtoolset-8/root/usr/bin ]]
++ dirname ./getdeps.sh
+ PROJECT_DIR=.
+ GETDEPS_PATHS=("$PROJECT_DIR/build/fbcode_builder/getdeps.py" "$PROJECT_DIR/../../opensource/fbcode_builder/getdeps.py")
++ pwd
+ ROOT_DIR=/home/julio-sandino/fork/mvfst
+ STAGE=/home/julio-sandino/fork/mvfst/_build/
+ mkdir -p /home/julio-sandino/fork/mvfst/_build/
+ for getdeps in "${GETDEPS_PATHS[@]}"
+ [[ -x ./build/fbcode_builder/getdeps.py ]]
+ ./build/fbcode_builder/getdeps.py build mvfst --current-project mvfst --install-prefix=/home/julio-sandino/fork/mvfst/_build/
Building on {distro=ubuntu, distro_vers=24.04, fb=off, fbsource=off, os=linux, test=on}
Assessing ninja...
Assessing cmake...
Assessing zlib...
Assessing zstd...
Assessing boost...
Assessing double-conversion...
Assessing fast_float...
Assessing fmt...
Assessing gflags...
Assessing glog...
Assessing googletest...
Assessing libaio...
Assessing libdwarf...
Assessing libevent...
Assessing lz4...
Assessing snappy...
Assessing liboqs...
Assessing autoconf...
Assessing automake...
Assessing libtool...
Assessing libsodium...
Assessing libiberty...
Assessing libunwind...
Assessing xz...
Using pinned rev c4209c5ecb1e8216ea20fc03fd8fdc7096a4c409 for https://github.com/facebook/folly.git
Assessing folly...
Using pinned rev c4209c5ecb1e8216ea20fc03fd8fdc7096a4c409 for https://github.com/facebook/folly.git
Using pinned rev 210f024169da22879a8d09b087c12db04e7de8dd for https://github.com/facebookincubator/fizz.git
Assessing fizz...
Using pinned rev 210f024169da22879a8d09b087c12db04e7de8dd for https://github.com/facebookincubator/fizz.git
Assessing mvfst...
Building mvfst...
....
....
-- Up-to-date: /home/julio-sandino/fork/mvfst/_build/mvfst/lib/libmvfst_fizz_handshake.a
-- Up-to-date: /home/julio-sandino/fork/mvfst/_build/mvfst/lib/libmvfst_fizz_server_handshake.a
-- Up-to-date: /home/julio-sandino/fork/mvfst/_build/mvfst/lib/libmvfst_fizz_server_handshake_handshake_app_token.a
+ exit 0
```

</details>

```
100% tests passed, 0 tests failed out of 1808

Total Test time (real) =   6.33 sec
```