### PR TITLE
fbcode_builder: force snappy to build with RTTI

### DIFF
--- a/build/fbcode_builder/manifests/snappy
+++ b/build/fbcode_builder/manifests/snappy
@@ -24,6 +24,12 @@ subdir = snappy-27ab5f7f518430a021239bc26a5b2fd64affbc7b
 [cmake.defines]
 SNAPPY_BUILD_TESTS = OFF
 SNAPPY_BUILD_BENCHMARKS = OFF
+# folly's Compression.cpp dynamic_casts snappy::Source/Sink and needs their
+# typeinfo. Snappy hardcodes -fno-rtti in CMAKE_CXX_FLAGS; override via the
+# per-config flags variable, which is appended after (last -f wins in gcc).
+CMAKE_CXX_FLAGS_RELWITHDEBINFO = -O2 -g -DNDEBUG -frtti
+CMAKE_CXX_FLAGS_RELEASE = -O3 -DNDEBUG -frtti
+CMAKE_CXX_FLAGS_DEBUG = -g -frtti
 
 # Avoid problems like `relocation R_X86_64_PC32 against symbol` on ELF systems
 # when linking rocksdb, which builds PIC even when building a static lib


### PR DESCRIPTION
Summary:
folly's `Compression.cpp` `dynamic_cast`s `snappy::Source` / `snappy::Sink`, which requires their typeinfo symbols. The snappy revision pinned in our manifest (`27ab5f7f...`) hardcodes `-fno-rtti` in `CMAKE_CXX_FLAGS` and even strips any `-frtti` we try to inject, so `libsnappy.so` ships without typeinfo for those polymorphic bases. Any downstream that actually pulls in folly's Snappy codec (proxygen, mvfst, folly's own `compression_compression_test` which is gated behind `BUILD_SLOW_TESTS`) fails to link with:

  undefined reference to `typeinfo for snappy::Source'

Override via `CMAKE_CXX_FLAGS_<CONFIG>`, which CMake appends after `CMAKE_CXX_FLAGS` and snappy doesn't touch — the trailing `-frtti` wins over the earlier `-fno-rtti` in gcc.

Differential Revision: D106941114


