### PR TITLE
Add transport setting to cap additional ACK blocks per ACK frame

### DIFF
--- a/quic/api/QuicAckScheduler.cpp
+++ b/quic/api/QuicAckScheduler.cpp
@@ -72,6 +72,7 @@ quic::Expected<Optional<PacketNum>, QuicError> AckScheduler::writeNextAcks(
       ackDelay, /* ackDelay */
       static_cast<uint8_t>(ackDelayExponentToUse), /* ackDelayExponent */
       conn_.connectionTime, /* connect timestamp */
+      conn_.transportSettings.maxAdditionalAckBlocksPerFrame,
   };
 
   auto ackWriteResult =

--- a/quic/codec/QuicWriteCodec.cpp
+++ b/quic/codec/QuicWriteCodec.cpp
@@ -228,13 +228,15 @@ quic::Expected<Optional<WriteCryptoFrame>, QuicError> writeCryptoFrame(
 
 /*
  * This function will fill the parameter ack frame with ack blocks from the
- * parameter ackBlocks until it runs out of space (bytesLimit). The largest
- * ack block should have been inserted by the caller.
+ * parameter ackBlocks until it runs out of space (bytesLimit) or hits
+ * maxAdditionalAckBlocks. The largest ack block should have been inserted by
+ * the caller.
  */
 [[nodiscard]] static quic::Expected<size_t, QuicError> fillFrameWithAckBlocks(
     const AckBlocks& ackBlocks,
     WriteAckFrame& ackFrame,
-    uint64_t bytesLimit) {
+    uint64_t bytesLimit,
+    uint64_t maxAdditionalAckBlocks) {
   PacketNum currentSeqNum = ackBlocks.crbegin()->start;
 
   // starts off with 0 which is what we assumed the initial ack block to be for
@@ -245,6 +247,9 @@ quic::Expected<Optional<WriteCryptoFrame>, QuicError> writeCryptoFrame(
   // Skip the largest, as it has already been emplaced.
   for (auto blockItr = ackBlocks.crbegin() + 1; blockItr != ackBlocks.crend();
        ++blockItr) {
+    if (numAdditionalAckBlocks >= maxAdditionalAckBlocks) {
+      break;
+    }
     const auto& currBlock = *blockItr;
     // These must be true because of the properties of the interval set.
     MVCHECK_GE(currentSeqNum, currBlock.end + 2);
@@ -571,8 +576,11 @@ maybeWriteAckBaseFields(
   spaceLeft -= headerSize;
 
   ackFrame.ackBlocks.push_back(ackState.acks.back());
-  auto numAdditionalAckBlocksResult =
-      fillFrameWithAckBlocks(ackState.acks, ackFrame, spaceLeft);
+  auto numAdditionalAckBlocksResult = fillFrameWithAckBlocks(
+      ackState.acks,
+      ackFrame,
+      spaceLeft,
+      ackFrameMetaData.maxAdditionalAckBlocks);
   if (numAdditionalAckBlocksResult.hasError()) {
     return quic::make_unexpected(numAdditionalAckBlocksResult.error());
   }

--- a/quic/codec/Types.h
+++ b/quic/codec/Types.h
@@ -21,6 +21,7 @@
 #include <quic/common/Variant.h>
 #include <quic/folly_utils/Utils.h>
 #include <quic/mvfst-config.h>
+#include <limits>
 
 /**
  * This details the types of objects that can be serialized or deserialized
@@ -306,6 +307,11 @@ struct WriteAckFrameMetaData {
 
   // Receive timestamps basis
   TimePoint connTime;
+
+  // Maximum number of additional ack blocks (beyond the required first
+  // block) to write into the frame. Defaults to unlimited, in which case
+  // only the space remaining in the packet bounds the block count.
+  uint64_t maxAdditionalAckBlocks{std::numeric_limits<uint64_t>::max()};
 };
 
 struct WriteAckFrameResult {

--- a/quic/codec/test/QuicWriteCodecTest.cpp
+++ b/quic/codec/test/QuicWriteCodecTest.cpp
@@ -1838,6 +1838,64 @@ TEST_P(QuicWriteCodecTest, WriteSomeAckBlocks) {
   }
 }
 
+TEST_F(QuicWriteCodecTest, WriteAckFrameWithMaxAdditionalAckBlocks) {
+  // Plenty of space in the packet, but the number of additional ack blocks
+  // is capped by maxAdditionalAckBlocks; the most recent blocks are kept.
+  MockQuicPacketBuilder pktBuilder;
+  setupCommonExpects(pktBuilder);
+
+  AckBlocks ackBlocks;
+  PacketNum currentEnd = 1000;
+  auto blockLength = 5;
+  auto gap = 10;
+  for (int i = 0; i < 30; i++) {
+    ackBlocks.insert({currentEnd - blockLength + 1, currentEnd});
+    currentEnd -= blockLength + gap;
+  }
+
+  TimePoint connTime = Clock::now();
+  WriteAckFrameState ackState =
+      createTestWriteAckState(FrameType::ACK, connTime, ackBlocks);
+  WriteAckFrameMetaData ackFrameMetaData = {
+      .ackState = ackState,
+      .ackDelay = 111us,
+      .ackDelayExponent = static_cast<uint8_t>(kDefaultAckDelayExponent),
+      .connTime = connTime,
+      .maxAdditionalAckBlocks = 3,
+  };
+
+  auto ackFrameWriteResultExpected =
+      writeAckFrame(ackFrameMetaData, pktBuilder, FrameType::ACK);
+  ASSERT_FALSE(ackFrameWriteResultExpected.hasError());
+  ASSERT_TRUE(ackFrameWriteResultExpected.value().has_value());
+  auto& ackFrameWriteResult = ackFrameWriteResultExpected.value().value();
+  // First ack block plus 3 additional ones.
+  EXPECT_EQ(ackFrameWriteResult.ackBlocksWritten, 4);
+
+  auto builtOut = std::move(pktBuilder).buildTestPacket();
+  auto regularPacket = builtOut.first;
+  WriteAckFrame& ackFrame = *regularPacket.frames.back().asWriteAckFrame();
+  EXPECT_EQ(ackFrame.ackBlocks.size(), 4);
+
+  auto wireBuf = std::move(builtOut.second);
+  BufQueue queue;
+  queue.append(wireBuf->clone());
+  QuicFrame decodedFrame = parseQuicFrame(queue);
+  auto& decodedAckFrame = *decodedFrame.asReadAckFrame();
+  EXPECT_EQ(decodedAckFrame.largestAcked, 1000);
+  ASSERT_EQ(decodedAckFrame.ackBlocks.size(), 4);
+  // Decoded blocks are ordered largest to smallest packet number; the 4
+  // blocks covering the most recent packets survive the cap.
+  EXPECT_EQ(decodedAckFrame.ackBlocks[0].startPacket, 996);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[0].endPacket, 1000);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[1].startPacket, 981);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[1].endPacket, 985);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[2].startPacket, 966);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[2].endPacket, 970);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[3].startPacket, 951);
+  EXPECT_EQ(decodedAckFrame.ackBlocks[3].endPacket, 955);
+}
+
 TEST_P(QuicWriteCodecTest, NoSpaceForAckBlockSection) {
   MockQuicPacketBuilder pktBuilder;
   pktBuilder.remaining_ = 6;

--- a/quic/state/TransportSettings.h
+++ b/quic/state/TransportSettings.h
@@ -13,6 +13,7 @@
 #include <quic/priority/PriorityQueue.h>
 #include <chrono>
 #include <cstdint>
+#include <limits>
 
 namespace quic {
 
@@ -426,6 +427,15 @@ struct TransportSettings {
   // are enabled or not and should not a part of
   //  maybeAckReceiveTimestampsConfigSentToPeer optional.
   uint64_t maxReceiveTimestampsPerAckStored{kMaxReceivedPktsTimestampsStored};
+
+  // Maximum number of additional ack blocks (beyond the required first
+  // block) included in each ACK frame sent to the peer. Bounds ACK frame
+  // size when ack ranges accumulate faster than they are coalesced, e.g.
+  // datagram-heavy workloads on lossy networks where gaps are never
+  // retransmitted. The most recent (largest packet number) blocks are kept.
+  // Unlimited by default; only the space remaining in the packet bounds the
+  // block count.
+  uint64_t maxAdditionalAckBlocksPerFrame{std::numeric_limits<uint64_t>::max()};
 
   // When true, advertise the draft-ietf-quic-receive-ts-02 transport
   // parameters (TP 0x4ac07, 0x4ac26) whenever


### PR DESCRIPTION
## Summary

There is currently no way to bound the number of ack blocks written into an ACK frame. As described in #357, datagram-heavy workloads on lossy networks accumulate ack ranges that are never coalesced (lost packet numbers are never retransmitted), so ACK frames grow until they fill the packet and can consume significant bandwidth relative to the application payload (frames over 1000 bytes were observed with sub-100-byte datagrams).

This adds `transportSettings.maxAdditionalAckBlocksPerFrame`, which caps the number of additional ack blocks (beyond the required first block) written into each outgoing ACK frame:

- The cap is enforced in `fillFrameWithAckBlocks`, the single choke point shared by all ACK variants (`ACK`, `ACK_ECN`, `ACK_RECEIVE_TIMESTAMPS`, `ACK_EXTENDED`, and the draft-02 receive-timestamps frames), so it applies uniformly.
- Blocks covering the most recent packet numbers are kept, matching the existing space-limited truncation behavior.
- The default is unlimited, so existing behavior is unchanged unless the setting is lowered.

Per RFC 9000 §13.2.3, a receiver may limit the number of ACK Ranges it reports, so a capped frame remains fully spec-compliant.

Fixes #357

## Test Plan

Added `QuicWriteCodecTest.WriteAckFrameWithMaxAdditionalAckBlocks`: writes 30 ack blocks with the cap set to 3 and verifies via encode + decode round trip that exactly 4 blocks (first + 3 additional) covering the most recent packet numbers are emitted.

```
buck test //quic/codec/test:QuicWriteCodecTest
```