### PR TITLE
docs: improve cross-platform contributor onboarding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.patch text eol=lf
+*.diff text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,29 @@ We actively welcome your pull requests.
 1. If you've added code that should be tested, add tests
 1. If you've changed APIs, update the documentation.
 1. Ensure the test suite passes.
-1. Make sure your code lints.
+1. Run the local validation steps described below.
 1. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Local Validation
+
+Run the build and test commands from the repository root before opening a pull
+request:
+
+```sh
+python3 ./build/fbcode_builder/getdeps.py build mvfst --install-prefix="$(pwd)/_build"
+python3 ./build/fbcode_builder/getdeps.py test mvfst --install-prefix="$(pwd)/_build"
+```
+
+On Windows, use the PowerShell build setup and command documented in the
+[README](README.md#building-mvfst). The equivalent commands use `python` and
+an absolute install prefix.
+
+For C++ changes, format each modified file with `clang-format` before
+committing:
+
+```sh
+clang-format -i path/to/changed_file.cpp path/to/changed_file.h
+```
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You
@@ -36,8 +57,7 @@ the process outlined on that page and do not file a public issue.
 
 ## Coding Style
 We use clang-format tool for coding style.
-Please run `clang-format -i <filename>` on file, where changes has been made
-before you commit them.
+Please run it on each C++ file where changes were made before committing.
 
 ## License
 By contributing to MVFST, you agree that your contributions will be

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ The settings for mvfst's cmake build are held in its getdeps manifest `build/fbc
 
 #### Dependencies
 
+#### Windows
+
+The Windows build requires Python 3, Git, and the Visual Studio 2022 C++
+Build Tools workload with a Windows SDK installed. After cloning the
+repository, configure Git from the repository directory so dependency patch
+files and long paths are handled consistently:
+
+    git config core.longpaths true
+    git config core.autocrlf false
+
+The recommended Windows build uses `getdeps.py` directly. An absolute install
+prefix avoids resolving `_build` relative to the dependency scratch directory:
+
+    $installPrefix = Join-Path (Get-Location) "_build"
+    python .\build\fbcode_builder\getdeps.py build --build-type RelWithDebInfo --src-dir=. mvfst "--install-prefix=$installPrefix"
+
 If on Linux or MacOS (with homebrew installed) you can install system dependencies to save building them:
 
     # Clone the repo

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ and to run a client:
 ```
 ./echo -mode=client -host=<host> -port=<port>
 ```
+
+On Windows, run the executable from PowerShell with the same options:
+
+```powershell
+.\echo.exe -mode=server -host=127.0.0.1 -port=4433
+.\echo.exe -mode=client -host=127.0.0.1 -port=4433
+```
+
 For more options, see
 ```
 ./echo --help


### PR DESCRIPTION
## Summary

- Keep dependency patch and diff files in LF format across platforms.
- Document the Windows build prerequisites and a PowerShell `getdeps.py` build command.
- Replace vague contributor validation guidance with concrete build, test, and formatting commands.
- Add PowerShell commands for running the Windows echo sample.

## Motivation

The repository supports Windows, but the contributor-facing documentation did
not explain the required C++ toolchain or provide Windows-native examples. In
addition, dependency patches can be checked out with Windows line endings,
which can cause `git apply` to reject an otherwise valid patch.

These changes improve first-time contributor onboarding without changing
mvfst runtime behavior or public APIs.

## Validation

- Verified the contribution branch is based on the latest upstream `main`.
- Ran `git diff --check` against `upstream/main`.
- Verified dependency patch files resolve to `text eol=lf` through Git attributes.
- Reviewed the documented commands against the repository's supported
  `getdeps.py` build and test workflow.

No C++ source or runtime behavior was changed.
