### PR TITLE
docs: correct deprecated build script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ By default `getdeps.py` will build the tests for mvfst. You can use it to run th
 
     python3 ./build/fbcode_builder/getdeps.py test mvfst --install-prefix=$(pwd)/_build
 
-### Method 2 \[Deprecated]: Using build.sh script
+### Method 2 \[Deprecated]: Using build_helper.sh script
 
 This method can be used on Ubuntu 18+ and macOS.
 
@@ -156,7 +156,7 @@ For `getdeps.py` build, you can find the echo binary at:
 cd $(python3 ./build/fbcode_builder/getdeps.py show-build-dir mvfst)/quic/samples/echo
 ```
 
-For the deprecated `build.sh` script, it will be at the following location if you used the default build path.
+For the deprecated `build_helper.sh` script, it will be at the following location if you used the default build path.
 ```
 cd ./_build/build/quic/samples/echo
 ```


### PR DESCRIPTION
## Summary

- Correct the deprecated build method heading to reference `build_helper.sh`.
- Correct the deprecated build output path description to reference the same script.

## Motivation

The README referred to `build.sh`, but this repository's deprecated helper is
`build_helper.sh`. The mismatch can send contributors looking for a script
that does not exist and makes the documented output path harder to trust.

This is a documentation-only correction; it does not change the build system
or runtime behavior.

## Validation

- Confirmed `build_helper.sh` exists in the repository.
- Confirmed no stale `build.sh` reference remains in `README.md`.
- Ran `git diff --check`.
