### PR TITLE
docs: align contributor license wording with project license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,4 @@ before you commit them.
 
 ## License
 By contributing to MVFST, you agree that your contributions will be
-licensed under its BSD license.
+licensed under its MIT license.


### PR DESCRIPTION
## Summary

- Correct the contributor license wording from BSD to MIT.

## Motivation

The repository's `LICENSE` file identifies mvfst as MIT licensed, while
`CONTRIBUTING.md` incorrectly described contributions as being licensed under
BSD. This change aligns the contributor guidance with the project's actual
license.

This is a documentation-only correction with no runtime or API impact.

## Validation

- Confirmed the first line of `LICENSE` is `MIT License`.
- Confirmed the stale BSD wording is absent from `CONTRIBUTING.md`.
- Ran `git diff --check`.
