### PR TITLE
Fix missing target library (mvfst_client_client) for samples/echo

### DIFF
--- a/quic/samples/CMakeLists.txt
+++ b/quic/samples/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_options(
 target_link_libraries(
   echo PUBLIC
   mvfst_test_utils
+  mvfst_client_client
   ${GFLAGS_LIBRARIES}
   ${LIBGMOCK_LIBRARIES}
 )


### PR DESCRIPTION
## Summary

Building the samples resulted in a linker error:

undefined reference to `quic::QuicClientTransportLite::...` undefined reference to `vtable for quic::QuicClientTransport' undefined reference to `VTT for quic::QuicClientTransport'

This may have been introduced in 5cd8b2b, with the addition of QuicClientTransportLite.

## Testing

./getdeps.sh --extra-cmake-defines '{"BUILD_SAMPLES":"ON"}'

This should produce:

...build/mvfst/quic/samples/echo