### PR TITLE
Fix gcc build of DatagramFlowManager nested queue types

### DIFF
--- a/quic/datagram/DatagramFlowManager.h
+++ b/quic/datagram/DatagramFlowManager.h
@@ -33,6 +33,10 @@ class DatagramFlowManager {
   // reach back to age it, and a flow that never sets one never reads the
   // clock.
   struct QueuedDatagram {
+    // User-provided, not `= default`: writeBuffer_ instantiates F14FastMap over
+    // these nested types before gcc has evaluated their member initializers.
+    QueuedDatagram() {}
+
     BufQueue buf;
     TimePoint enqueueTime{TimePoint::max()};
     // Orders this datagram against others in the same flow; lower is sent
@@ -51,7 +55,7 @@ class DatagramFlowManager {
     // popped. Set by closeFlow(), and at creation for ephemeral flows.
     bool draining{false};
 
-    DatagramFlowQueue() = default;
+    DatagramFlowQueue() {} // Not `= default`; see QueuedDatagram above.
     ~DatagramFlowQueue() = default;
 
     // Move-only


### PR DESCRIPTION
gcc fails to compile this header because the F14FastMap member instantiates traits over QueuedDatagram and DatagramFlowQueue while their default member initializers are still being parsed, so the implicitly defaulted constructors are not usable yet. Give both structs a user-provided `{}` default constructor instead of `= default`, which delays the constructor definition until the enclosing class is complete. Construction behavior is unchanged: the member initializers still supply the same defaults.